### PR TITLE
(PULSE-4397) Fix event aggregation bug.

### DIFF
--- a/libraries/datadogstatsd.php
+++ b/libraries/datadogstatsd.php
@@ -39,7 +39,7 @@ class Datadogstatsd {
     /**
      * @var string Config for submitting events via 'TCP' vs 'UDP'; default 'UDP'
      */
-    static private $__submitEventsOver = 'UDP' ;
+    static private $__submitEventsOver = self::SEND_UDP ;
 
     const OK        = 0;
     const WARNING   = 1;


### PR DESCRIPTION
The mainline version of `php-datadogstatsd` neglects the `aggregation_key` attribute when composing events for dispatch over UDP. This PR is a fix for the bug on our fork of the library.

## :fast_forward: Strategy ##

This PR will be part of a "hotfix" release for `php-datadogstatsd` version 0.4.0, but released from our fork rather than their mainline. Once this PR is tested, we will cut a 0.4.0.1 hotfix release which includes this fix, then change the `composer.json` in Joka to pick up _our_ version of the library instead of the mainline. This is necessary only because the composer works with release tags; we must release in order to make the changes accessible to the SCM tools for Joka.

See also [`PULSE` PR#650](https://github.com/istresearch/PULSE/pull/650), which plans to make use of this hotfix release.

## :gear: Test Setup ##

In absence of a composed release, the tester may set up a test by copying the `datadogstatsd.php` file from the `libraries/` directory to the `lib/vendor/php-datadogstatsd/libraries/` directory in a test instance of Joka. Tests of this PR _do not_ require use of the code from the corresponding `PULSE` PR; the test case below actually assumes that your test instance _does not_ have the updated Joka code.

## :mag: Test Case ##

1. Use Postman or similar tool to send an authenticated request to the `/api/data_dog/execute` REST endpoint on your test instance.
    * **VERIFY:** A component version report is visible in DataDog for this instance. (A gateway silence alert may also be generated, depending on the current disposition of gateway devices.) This verifies previous behavior; it is not a change of behavior.
2. Make the same request several times over any reasonable period of time. 
    * **EXPECT:** The component version reports are aggregated in the DataDog event timeline.



